### PR TITLE
Back port from AnyEvent::HTTP::Server::II 1.9999

### DIFF
--- a/lib/AnyEvent/HTTP/Server.pm
+++ b/lib/AnyEvent/HTTP/Server.pm
@@ -43,13 +43,14 @@ sub MAX_READ_SIZE () { 128 * 1024 }
 sub DEBUG () { 0 }
 
 our $LF = "\015\012";
-our $ico = Compress::Zlib::memGunzip pack "H*",
+my $ico_pk = pack "H*",
 	"1f8b08000000000000ff636060044201010620a9c090c1c2c020c6c0c0a001c4".
 	"4021a008441c0c807242dc100c03ffffff1f1418e2144c1a971836fd308c4f3f".
 	"08373434609883ac06248fac161b9b16fe47772736bfe1b29f1efa89713f363b".
 	"08d98d1ceec4b89f5cfd84dc8f4f3f480e19131306a484ffc0610630beba9e81".
 	"e1e86206860bcc10fec966289ecfc070b01d48b743d820b187cd0c707d000409".
 	"1d8c7e040000";
+our $ico = Compress::Zlib::memGunzip $ico_pk;
 
 sub start { croak "It's a new version of ".__PACKAGE__.". For old version use `legacy' branch, or better make some minor patches to support new version" };
 sub stop  { croak "It's a new version of ".__PACKAGE__.". For old version use `legacy' branch, or better make some minor patches to support new version" };
@@ -89,7 +90,7 @@ sub new {
 		open my $f, '<:raw', $self->{favicon} or die "Can't open favicon: $!";
 		local $/;
 		<$f>;
-	} : $ico );
+	} : $ico ) if !exists $self->{favicon} or $self->{favicon};
 	$self->{request} = 'AnyEvent::HTTP::Server::Req';
 	
 	return $self;

--- a/lib/AnyEvent/HTTP/Server/Req.pm
+++ b/lib/AnyEvent/HTTP/Server/Req.pm
@@ -449,6 +449,7 @@ use Digest::SHA1 'sha1';
 					$self->[3]->(\undef) if $self->connection eq 'close' or $self->[SERVER]{graceful};
 					delete $self->[3];
 				}
+				undef $self->[4];
 			}
 			elsif(defined $self->[4]) {
 				${ $self->[REQCOUNT] }--;
@@ -476,7 +477,8 @@ use Digest::SHA1 'sha1';
 					$self->[3]->( \("1$LF"));
 					$self->[3]->( \undef);
 					delete $self->[3];
-				}			
+				}
+				undef $self->[4];
 			}
 			elsif (defined $self->[4]) {
 				${ $self->[REQCOUNT] }--;

--- a/lib/AnyEvent/HTTP/Server/Req.pm
+++ b/lib/AnyEvent/HTTP/Server/Req.pm
@@ -452,12 +452,12 @@ use Digest::SHA1 'sha1';
 				undef $self->[4];
 			}
 			elsif(defined $self->[4]) {
-				${ $self->[REQCOUNT] }--;
 				undef $self->[4];
 			}
 			else {
 				die "Need to be chunked reply";
 			}
+			${ $self->[REQCOUNT] }--;
 			if ( $self->attrs->{sent_headers} ) {
 				my $h = delete $self->attrs->{sent_headers};
 				if( $self->[8] && $self->[8]->{on_reply} ) {
@@ -481,12 +481,12 @@ use Digest::SHA1 'sha1';
 				undef $self->[4];
 			}
 			elsif (defined $self->[4]) {
-				${ $self->[REQCOUNT] }--;
 				undef $self->[4];
 			}
 			else {
 				die "Need to be chunked reply";
 			}
+			${ $self->[REQCOUNT] }--;
 			if ( $self->attrs->{sent_headers} ) {
 				my $h = delete $self->attrs->{sent_headers};
 				if( $self->[8] && $self->[8]->{on_reply} ) {


### PR DESCRIPTION
Pack returns constant string in Perl 5.18, so it makes unavailable to call memgunzip on it.
Also, fixed bug on Chunked reply 'cause REQCOUNT and elses
