### PR TITLE
Return $@ to state before eval

### DIFF
--- a/lib/AnyEvent/HTTP/Server/Req.pm
+++ b/lib/AnyEvent/HTTP/Server/Req.pm
@@ -506,6 +506,7 @@ use Digest::SHA1 'sha1';
 			my $caller = "@{[ (caller)[1,2] ]}";
 			#warn "Destroy req $self->[0] $self->[1] by $caller";
 			if( $self->[3] ) {
+				local $@;
 				eval {
 					if ($self->[4]) {
 						$self->abort();


### PR DESCRIPTION
Look! When AnyEvent::HTTP::Server::Req destroys it tries to send to client
500 On Not Handled under eval. If Not Handled was unexpected like (ex.
die in callback) we may be in state when $EV::DIED has not been called
yet. So we MUST keep old value of $@ to let EV-loop being available for
check if was something wrong in callbacks