### PR TITLE
Hash req

### DIFF
--- a/lib/AnyEvent/HTTP/Server.pm
+++ b/lib/AnyEvent/HTTP/Server.pm
@@ -94,7 +94,7 @@ sub new {
 	if (!exists $self->{favicon}) {
 		$self->{favicon} = \$ico;
 	};
-	if (!ref $self->{favicon}) {
+	if ($self->{favicon} and !ref $self->{favicon}) {
 		$self->{favicon} = \do {
 			open my $f, '<:raw', $self->{favicon} or die "Can't open favicon: $!";
 			local $/;

--- a/lib/AnyEvent/HTTP/Server/Req.pm
+++ b/lib/AnyEvent/HTTP/Server/Req.pm
@@ -34,8 +34,16 @@ use POSIX qw(strftime);
 
 use MIME::Base64 qw(encode_base64);
 use Scalar::Util qw(weaken);
-use Digest::SHA1 'sha1';
 
+BEGIN {
+	if(eval{ require Digest::SHA1 }) {
+		Digest::SHA1->import('sha1');
+	} elsif(eval { require Digest::SHA }) {
+		Digest::SHA->import('sha1');
+	} else {
+		die 'need Digest::SHA1 or Digest::SHA';
+	}
+}
 	our $Server = 'AEHTS/'.$AnyEvent::HTTP::Server::VERSION;
 	our @hdr = map { lc $_ }
 	our @hdrn  = qw(


### PR DESCRIPTION
There are three patches.

First of all, there is no Digest::SHA1 package in the Ubuntu repositories.  Digest::SHA is slower than Digest::SHA1, but it's easy to use with Ubuntu Linux. This patch adds fall back to Digest::SHA.

Also there were a bug that treated an false favicon attribute as a favicon.ico path, instead of disabling favicon. The second commit fixes this issue.

The last one allows using pre-bounded sockets to create an server object. it's useful for code reloading.