### PR TITLE
There is new cookie param exists now

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ WriteMakefile(
 		AnyEvent       => 5,
 		'Digest::SHA1' => 2,
 		'JSON::XS'     => 3,
-		'HTTP::Easy'   => 0.02,
+		'HTTP::Easy'   => 0.04,
 	},
 	ABSTRACT_FROM     => 'lib/AnyEvent/HTTP/Server.pm', # retrieve abstract from module
 	AUTHOR            => 'Mons Anderson <mons@cpan.org>',

--- a/lib/AnyEvent/HTTP/Server.pm
+++ b/lib/AnyEvent/HTTP/Server.pm
@@ -8,7 +8,7 @@ AnyEvent::HTTP::Server - AnyEvent HTTP/1.1 Server
 
 our $VERSION;
 BEGIN{
-$VERSION = '1.99996';
+$VERSION = '1.99997';
 }
 
 use AnyEvent::HTTP::Server::Kit;

--- a/lib/AnyEvent/HTTP/Server/Req.pm
+++ b/lib/AnyEvent/HTTP/Server/Req.pm
@@ -375,6 +375,7 @@ BEGIN {
 									push @c, "path=" . $p;
 									push @c, "Secure"  if $o->{secure};
 									push @c, "HttpOnly"  if $o->{httponly};
+									push @c, "SameSite=" . $o->{samesite} if $o->{samesite};
 									push @bad, "\u\Lset-cookie\E: ". join('; ',@c) .$LF;
 								}
 							}


### PR DESCRIPTION
The SameSite attribute of the Set-Cookie HTTP response header allows you to declare if your cookie should be restricted to a first-party or same-site context.