### PR TITLE
Fix cookie parsing

### DIFF
--- a/lib/AnyEvent/HTTP/Server.pm
+++ b/lib/AnyEvent/HTTP/Server.pm
@@ -378,13 +378,14 @@ sub incoming {
 									$lastkey = lc $1;
 									$h{ $lastkey } = exists $h{ $lastkey } ? $h{ $lastkey }.','.$2: $2;
 									#warn "Captured header $lastkey = '$2'";
+									my $v = $2;
 									if ( defined $3 ) {
-										pos(my $v = $2) = $-[3] - $-[2];
-										#warn "scan ';'";
 										$h{ $lastkey . '+' . lc($1) } = ( defined $2 ? do { my $x = $2; $x =~ s{\\(.)}{$1}gs; $x } : $3 )
-											while ( $v =~ m{ \G ; \s* ([^\s=]++)\s*= (?: "((?:[^\\"]++|\\.){0,4096}+)" | ([^;,\s]++) ) \s* }gcxso ); # "
+											while ( $v =~ m{ \s* ([^\s=]++)\s*= (?: "((?:[^\\"]++|\\.){0,4096}+)" | ([^;,\s]++) ) \s* ;? }gcxso ); # "
 										$contstate = 1;
-									} else {
+									} else {							
+										$h{ $lastkey . '+' . lc($1) } = ( defined $2 ? do { my $x = $2; $x =~ s{\\(.)}{$1}gs; $x } : $3 )
+											if ( $v =~ m{ \s* ([^\s=]++)\s*= (?: "((?:[^\\"]++|\\.){0,4096}+)" | ([^;,\s]++) ) \s* ;? }xso ); # "
 										$contstate = 0;
 									}
 								}

--- a/t/basic.pl
+++ b/t/basic.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use Test::More tests => 224;
+use Test::More tests => 244;
 use Data::Dumper;
 use FindBin;
 use lib "$FindBin::Bin/..";
@@ -289,6 +289,23 @@ test_server {
 	return 200, undef;
 }	'200 - with undef body',
 	[["GET /test1 HTTP/1.1\nHost:localhost\nConnection:keep-alive\n\n"], 200, { 'content-length' => 0 }, "" ],
+if ALL;
+
+test_server {
+	my $s = shift;
+	my $r = shift;
+	return (
+		$r->method eq 'GET' ? 200 : 400,
+		"x=".$r->headers->{'cookie+x'}.",y=".$r->headers->{'cookie+y'},
+		headers => {
+		},
+	);
+}	'Cookies parsing',
+	[["GET /test1 HTTP/1.1\nCookie: x=1\n\n"],                          200, {  }, "x=1,y=" ],
+	[["GET /test2 HTTP/1.1\nCookie: x=1;y=2\n\n"],                      200, {  }, "x=1,y=2" ],
+	[["GET /test2 HTTP/1.1\nCookie: x=\"1\";y=2\n\n"],                  200, {  }, "x=1,y=2" ],
+	[["GET /test2 HTTP/1.1\nCookie: x=1;y=\"2\"\n\n"],                  200, {  }, "x=1,y=2" ],
+	[["GET /test2 HTTP/1.1\nCookie: x=\"1\";y=\"2\"\n\n"],              200, {  }, "x=1,y=2" ],
 if ALL;
 
 }


### PR DESCRIPTION
A request header like 
`Cookie: x=1; y=2; z=3`
was not parsed correctly: we got 
$request->headers containing `"cookies+y"` and `"cookies+z"` keys, but not `"cookies+x"`

The present pull request contains test and fixes for this.